### PR TITLE
Change captive portal default password

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The device is visible on the computer's WiFi network listing:
 <img src="media/wifi_selection.jpg" width="40%" />
 
 The network name is "Configure sh-wg-xxxxxxxxxxxx", the last 12 digits corresponding to the device unique identifier.
-You also need to provide a password to connect to the configuration portal. The password is "thisisfine".
+You also need to provide a password to connect to the configuration portal. The password is "abcdabcd".
 
 Once you have successfully connected to the configuration portal, you should be automatically presented with the WiFi configuration front page:
 

--- a/src/config.h
+++ b/src/config.h
@@ -35,5 +35,7 @@ constexpr unsigned long kTimeUpdatePeriodMs = 3600 * 1000;
 static constexpr int kDelayBetweenFirmwareUpdateChecksMs =
     60 * 60 * 1000;  // 1 hour
 
+// WiFi captive portal password
+constexpr char kWiFiCaptivePortalPassword[] = "abcdabcd";
 
 #endif // SH_WG_CONFIG_H_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -436,6 +436,16 @@ String MacAddrToString(uint8_t *mac, bool add_colons) {
   return mac_string;
 }
 
+void PrintProductInfo() {
+  uint8_t mac[6];
+  WiFi.macAddress(mac);
+  String mac_str = MacAddrToString(mac);
+
+  Serial.println("***** Product Info *****");
+  Serial.printf("%s %s %s\n", kFirmwareName, kFirmwareVersion, mac_str.c_str());
+  Serial.println("************************");
+}
+
 void SetupUIComponents() {
   checkbox_config_enable_firmware_updates = new CheckboxConfig(
       true, "Enable", "/System/Enable Firmware Updates",
@@ -488,6 +498,9 @@ void setup() {
     // don't continue with the generic setup
     return;
   }
+
+  // Print product information on the serial port
+  PrintProductInfo();
 
   // Create a unique hostname for the device.
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -506,7 +506,8 @@ void setup() {
   SetupUIComponents();
 
   networking = new Networking("/System/WiFi Settings", "", "",
-                              SensESPBaseApp::get_hostname(), "thisisfine");
+                              SensESPBaseApp::get_hostname(),
+                              kWiFiCaptivePortalPassword);
 
   networking->set_wifi_manager_ap_ssid(String("Configure SH-wg ") + mac_str);
 

--- a/src/shwg.h
+++ b/src/shwg.h
@@ -7,5 +7,6 @@ extern reactesp::ReactESP app;
 extern sensesp::SensESPMinimalApp *sensesp_app;
 
 String MacAddrToString(uint8_t *mac, bool add_colons = false);
+void PrintProductInfo();
 
 #endif

--- a/src/shwg_factory_test.cpp
+++ b/src/shwg_factory_test.cpp
@@ -76,7 +76,7 @@ static void PrepareWiFiNetworkScan() {
   app.onDelay(100, ScanWiFiNetworks);
 }
 
-static void PrintInfo() {
+static void PrintProductInfo() {
   uint8_t mac[6];
   WiFi.macAddress(mac);
   String mac_str = MacAddrToString(mac);
@@ -101,7 +101,7 @@ static void HandleFactoryTestButtonEvent(AceButton* button, uint8_t event_type,
         debugD("Detected a long press");
         // stop yellow LED blinking and turn it on
         ledcWrite(kYellowPWMChannel, 255);
-        PrintInfo();
+        PrintProductInfo();
       }
       break;
   }

--- a/src/shwg_factory_test.cpp
+++ b/src/shwg_factory_test.cpp
@@ -4,9 +4,9 @@
 #include "WiFi.h"
 #include "config.h"
 #include "elapsedMillis.h"
+#include "firmware_info.h"
 #include "sensesp.h"
 #include "shwg.h"
-#include "firmware_info.h"
 
 using namespace ace_button;
 using namespace sensesp;
@@ -76,18 +76,8 @@ static void PrepareWiFiNetworkScan() {
   app.onDelay(100, ScanWiFiNetworks);
 }
 
-static void PrintProductInfo() {
-  uint8_t mac[6];
-  WiFi.macAddress(mac);
-  String mac_str = MacAddrToString(mac);
-
-  Serial.println("***** Product Info *****");
-  Serial.printf("%s %s %s\n", kFirmwareName, kFirmwareVersion, mac_str.c_str());
-  Serial.println("************************");
-}
-
 static void HandleFactoryTestButtonEvent(AceButton* button, uint8_t event_type,
-                                  uint8_t button_state) {
+                                         uint8_t button_state) {
   digitalWrite(kRedLedPin, button_state);
   static elapsedMillis time_since_press_event;
 


### PR DESCRIPTION
Changed the captive portal default password to a more neutral one.

Also print product information at device boot. Helps with reflashing existing devices.