### PR TITLE
fix path to ui_output.h

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@
 #include "sensesp/net/networking.h"
 #include "sensesp/system/lambda_consumer.h"
 #include "sensesp/system/led_blinker.h"
-#include "sensesp/system/ui_output.h"
+#include "sensesp/ui/ui_output.h"
 #include "sensesp/transforms/lambda_transform.h"
 #include "sensesp_minimal_app_builder.h"
 #include "shwg.h"


### PR DESCRIPTION
Removes a warning message from compiler output.  Due to ui_output.h having been moved.